### PR TITLE
Fix: Update broken YouTube button link in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ Join our ever-growing community and stay updated on our activities through our s
 [![Facebook Page](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/CATReloaded)
 [![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/CATReloaded)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/cat-reloaded/)
-[![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/user/CATReloaded)
+[![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/@CATReloaded)
 [![WhatsApp](https://img.shields.io/badge/WhatsApp-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://whatsapp.com/channel/0029Vap49WE4NVioCIZs3y2p)
 
 🚀 **Join us, contribute, and be part of the next tech revolution!**


### PR DESCRIPTION
This PR updates the broken YouTube button link in the CAT Reloaded README.md file.

- Fixed the incorrect YouTube link.

- Ensured the button now redirects correctly.

![Screenshot from 2025-03-25 21-46-22](https://github.com/user-attachments/assets/1b8fdd7c-3f4b-4bd6-86d7-68b4df04b99a)
