### PR TITLE
feat(frontend): overhaul Frontend Circle roadmap for 2026 season

### DIFF
--- a/Front End/Readme.md
+++ b/Front End/Readme.md
@@ -1,797 +1,124 @@
 <img src="./roadmap_bg.png"/>
 
-`Ihab Mahmoud`
+# ��� CAT Reloaded — Frontend Circle Roadmap 2026
 
-# CAT Frontend Roadmap: Developer Learning Path
+> **"Code is easy. Discipline is hard."**
 
-**A skilled developer is always curious.**  
-
-This guide provides a structured path to mastering web development fundamentals, core concepts, and more advanced frameworks.  
-
-<br/>
-
-## 1. Basics
-
- ### A. Introduction
-
-Front-end development involves creating the **visual and interactive components** of websites or applications, including layout, styling, and interactive > elements. As businesses move online, front-end development has become an increasingly valuable skill.
-
-<br/>
-
-### Recommended Resources
-> - [The Front-end Development Tech/Spec Overview ](https://frontendmasters.com/guides/learning-roadmap/front-end-development-overview/#1)
-> - [How does the Internet work? ](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/How_does_the_Internet_work)
-> - [World Wide Web (WWW) Basic Mechanics ](https://frontendmasters.com/guides/learning-roadmap/www-basic-mechanics/)
-> - [An Overview of HTTP ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview)
-> - [How The Web Works ](https://academind.com/tutorials/how-the-web-works)
-> - [What is a web browser? ](https://www.mozilla.org/en-US/firefox/browsers/what-is-a-browser/)
-> - [How Browsers Work ](https://www.freecodecamp.org/news/web-application-security-understanding-the-browser-5305ed2f1dac/)
-> - [What is DNS? ](https://aws.amazon.com/route53/what-is-dns/)
->  - [What is a domain name? ](https://www.cloudflare.com/learning/dns/glossary/what-is-a-domain-name/)
- 
-<br/>
-
-### Git & GitHub
-
-**GitHub** is a web-based platform for **version control and collaboration**. It allows developers to work together, manage code changes, and track the history of their projects.
-
-#### Git - Version Control
-Git is a **version control system** that enables collaboration, versioning, and rollback in source code projects.
-
-<br/>
-
-### Resources to Learn Git & GitHub
->- [Learn Git and GitHub](https://www.youtube.com/playlist?list=PLDoPjvoNmBAw4eOj58MZPakHjaO3frVMF) [Elzero Web School]
->- [learn Git in Arabic](https://www.youtube.com/playlist?list=PLfDx4cQoUNOYVfQs_NFNyykcqkaJ_plmK) [Algorithm Academy]
->- [**Git and GitHub | شخبط وانت متطمن](https://www.youtube.com/watch?v=Q6G-J54vgKc) [Recommended]
->- [Git book - Git ](https://git-scm.com/book/en/v2)
->- [Git Cheat Sheet repo ](https://github.com/FADL285/git-cheat-sheet)
->- [GitHub Guides ](https://guides.github.com/activities/hello-world/)
-
-<br/>
-
-### Suggested Accounts to Create
->- [LinkedIn](https://www.linkedin.com/) - Professional networking
->- [GitHub](https://github.com/) - Code repositories and collaboration
->- [LeetCode](https://leetcode.com/) - Coding practice and problem-solving
-
-<br/>
-
-### Tools
-
->- **Download** [Visual Studio Code (VSCode)](https://code.visualstudio.com/Download) - Text editor
->- **Download** [Git](https://git-scm.com/downloads) - Version control system
-
-<br/>
+![HTML](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
+![CSS](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=323330)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![React](https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=react&logoColor=323330)
+![Vue](https://img.shields.io/badge/Vue.js-4FC08D?style=for-the-badge&logo=vue.js&logoColor=white)
+![Angular](https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=next.js&logoColor=white)
+![SASS](https://img.shields.io/badge/SASS-CC6699?style=for-the-badge&logo=sass&logoColor=white)
+![Tailwind](https://img.shields.io/badge/Tailwind_CSS-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
 
 ---
 
-<br/>
+## ��� Curriculum at a Glance
 
-### B. HTML
+This roadmap is divided into **3 phases** across ~26 weeks, covering everything from HTML basics to production-grade fullstack applications.
 
-HTML stands for **Hypertext Markup Language** and is the standard language for creating web pages. It is used to structure content and provide meaning to web elements like text, images, and multimedia. With HTML, developers can create accessible, responsive, and visually appealing websites.
+| | Phase | Duration | Core Topics | Outcome |
+|:---:|:---|:---:|:---|:---|
+| ���️ | **Foundation** | 5 Weeks | HTML · CSS · Git · Responsive Design | Build & deploy static websites |
+| ⚙️ | **Core Engineering** | 13 Weeks | JavaScript · DOM · API · OOP · SASS · NPM | Solve problems & build interactive apps |
+| ⚛️ | **Specialization** | 8 Weeks | React / Vue / Angular · State Mgmt · SSR | Ship production-grade SPAs & fullstack apps |
 
-HTML employs a series of tags to define a web page's structure and layout. For instance, the `<html>` tag marks the beginning and end of an HTML document, while the `<head>` and `<body>` tags define the document's structure.
-
-<br/>
-
-## 📺 HTML Playlist
-
-[**Learn HTML In Arabic 2021 - Elzero Web School**](https://youtube.com/playlist?list=PLDoPjvoNmBAw_t_XWUFbBX-c9MafPk9ji)
-
-| **Videos** | **Assignments** | **Assignments Links** |
-| --- | --- | --- |
-| 1 ⇒ 5 | 4 assignments | [**تكليفات الدروس من الدرس 01 إلى 05**](https://elzero.org/html-assignments-lesson-from-1-to-5/) |
-| 6 ⇒ 10 | 7 assignments | [**تكليفات الدروس من الدرس 6 إلى 10**](https://elzero.org/html-assignments-lesson-from-6-to-10/) |
-| 11 ⇒ 14 | 4 assignments | [**تكليفات الدروس من الدرس 11 إلى 14**](https://elzero.org/html-assignments-lesson-from-11-to-14/) |
-| 15 ⇒ 18 | 3 assignments | [**تكليفات الدروس من الدرس 15 إلى 18**](https://elzero.org/html-assignments-lesson-from-15-to-18/) |
-| 19 ⇒ 23 | 4 assignments | [**تكليفات الدروس من الدرس 19 إلى 23**](https://elzero.org/html-assignments-lesson-from-19-to-23/) |
-| 24 ⇒ 27 | 2 assignments | [**تكليفات الدروس من الدرس 24 إلى 27**](https://elzero.org/html-assignments-lesson-from-24-to-27/) |
-| 28 ⇒ 30 | 3 assignments | [**تكليفات الدروس من الدرس 28 إلى 30**](https://elzero.org/html-assignments-lesson-from-28-to-30/) |
-| 31 ⇒ 34 | 4 assignments | [**تكليفات الدروس من الدرس 31 إلى 34**](https://elzero.org/html-assignments-lesson-from-31-to-34/) |
-| 35 ⇒ 37 | 2 assignments | [**تكليفات الدروس من الدرس 35 إلى 37**](https://elzero.org/html-assignments-lesson-from-35-to-37/) |
-
-<br/>
-
-## 📚 HTML Resources
-
-> - [**HTML Tutorial - W3Schools**](https://www.w3schools.com/html/default.asp) 📖
-> - [**HTML Basics - MDN Web Docs**](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics) 📖
-
-<br/>
+> **Total:** ~26 weeks · 15+ hands-on projects · 3 framework tracks
 
 ---
 
-<br/>
+## ���️ Roadmap Files
 
-### C. CSS
+### ���️ Phase 1 — The Foundation
+> HTML, CSS, Git & Responsive Design
 
-CSS stands for Cascading Style Sheets and is a fundamental technology used for web design. It is used to define the style, layout, and formatting of HTML documents. With CSS, developers can separate the presentation of a web page from the content, which makes it easier to design and maintain websites. CSS is used to control the layout of multiple web pages all at once, making it a powerful tool for web designers.
+��� **[View Phase 1 Roadmap →](./roadmap-01-foundation.md)**
 
-<br/>
-
-## 📺 CSS Playlist
-
-[**Learn CSS In Arabic 2021 Elzero Web School**](https://youtube.com/playlist?list=PLDoPjvoNmBAzjsz06gkzlSrlev53MGIKe)
-
-
-### Week 1
-| **Videos** | **Assignments** | **Assignments Links** |
-| --- | --- | --- |
-| lessons from 01 to 04 | 6 assignments | [تكليفات من 01 الى 04](https://elzero.org/css-assignments-lesson-from-1-to-4/) |
-| lessons from 05 to 08 | 4 assignments | [تكليفات من 05 الى 08](https://elzero.org/css-assignments-lesson-from-5-to-8/) |
-| lessons from 09 to 12 | 2 assignments | [تكليفات من 09 الى 12](https://elzero.org/css-assignments-lesson-from-9-to-12/) |
-| lessons from 13 to 16 | 2 assignments | [تكليفات من 13 الى 16](https://elzero.org/css-assignments-lesson-from-13-to-16/) |
-| lessons from 17 to 21 | 4 assignments | [تكليفات من 17 الى 21](https://elzero.org/css-assignments-lesson-from-17-to-21/) |
-| lessons from 22 to 26 | 3 assignments | [تكليفات من 22 الى 26](https://elzero.org/css-assignments-lesson-from-22-to-26/) |
-| lessons from 27 to 29 | 2 assignments | [تكليفات من 27 الى 29](https://elzero.org/css-assignments-lesson-from-27-to-29/) |
-| lessons from 30 to 33 | 4 assignments | [تكليفات من 30 الى 33](https://elzero.org/css-assignments-lesson-from-30-to-33/) |
-| lessons from 34 to 37 | 4 assignments | [تكليفات من 34 الى 37](https://elzero.org/css-assignments-lesson-from-34-to-37) |
-| lessons from 38 to 41 | 3 assignments | [تكليفات من 38 الى 41](https://elzero.org/css-assignments-lesson-from-38-to-41/) |
-| lessons from 42 to 45 | 3 assignments | [تكليفات من 42 الى 45](https://elzero.org/css-assignments-lesson-from-42-to-45/) |
-| lessons from 46 to 53 | 6 assignments | [تكليفات من 46 الى 53](https://elzero.org/css-assignments-lesson-from-46-to-53/) |
-
-### Week 2
-| **Videos** | **Assignments** | **Assignments Links** |
-| --- | --- | --- |
-| lessons from 54 to 56 | 2 assignments | [تكليفات من 54 الى 56](https://elzero.org/css-assignments-lesson-from-54-to-56/) |
-| lessons from 57 to 64 | 6 assignments | [تكليفات من 57 الى 64](https://elzero.org/css-assignments-lesson-from-57-to-64/) |
-| lessons from 65 to 67 | 3 assignments | [تكليفات من 65 الى 67](https://elzero.org/css-assignments-lesson-from-65-to-67/) |
-
-### Week 3
-| **Videos** | **Assignments** | **Assignments Links** |
-| --- | --- | --- |
-| lessons from 68 to 73 | 5 assignments | [تكليفات من 68 الى 73](https://elzero.org/css-assignments-lesson-from-68-to-73/) |
-| lessons from 74 to 77 | 4 assignments | [تكليفات من 74 الى 77](https://elzero.org/css-assignments-lesson-from-74-to-77/) |
-| lessons from 78 to 82 | 8 assignments | [تكليفات من 78 الى 82](https://elzero.org/css-assignments-lesson-from-78-to-82/) |
-| lessons from 83 to 85 | 3 assignments | [تكليفات من 83 الى 85](https://elzero.org/css-assignments-lesson-from-83-to-85/) |
-| lessons from 86 to 88 | 2 assignments | [تكليفات من 86 الى 88](https://elzero.org/css-assignments-lesson-from-86-to-88/) |
-
-<br/>
-
-## 📚 CSS Resources
-
-> - [Learn CSS (web.dev)](https://web.dev/learn/css/) 📖
-> - [CSS Tutorial - W3Schools](https://www.bing.com/ck/a?!&&p=5fa2d544e23c386eJmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTE4OQ&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=w3schools%2fcss&u=a1aHR0cHM6Ly93d3cudzNzY2hvb2xzLmNvbS9Dc3Mv&ntb=1) **📖**
-> - [A Complete Guide to Flexbox | CSS-Tricks - CSS-Tricks](https://www.bing.com/ck/a?!&&p=78ac93d4b61954fcJmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTI4NA&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=css+flexbox+article&u=a1aHR0cHM6Ly9jc3MtdHJpY2tzLmNvbS9zbmlwcGV0cy9jc3MvYS1ndWlkZS10by1mbGV4Ym94Lw&ntb=1) **📖**
-> - [A Complete Guide to CSS Grid | CSS-Tricks - CSS-Tricks](https://www.bing.com/ck/a?!&&p=80825168f57741b4JmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTI4NA&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=css+grid+article&u=a1aHR0cHM6Ly9jc3MtdHJpY2tzLmNvbS9zbmlwcGV0cy9jc3MvY29tcGxldGUtZ3VpZGUtZ3JpZC8&ntb=1) **📖**
-> - [position | CSS-Tricks - CSS-Tricks](https://www.bing.com/ck/a?!&&p=d7d0d33d07de54b0JmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTQzMQ&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=css+positions+article&u=a1aHR0cHM6Ly9jc3MtdHJpY2tzLmNvbS9hbG1hbmFjL3Byb3BlcnRpZXMvcC9wb3NpdGlvbi8&ntb=1) **📖**
-> - [Everything you need to know about CSS Variables](https://www.bing.com/ck/a?!&&p=ff418981d8895dffJmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTMxMQ&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=css+variables+article&u=a1aHR0cHM6Ly9jc3MtdHJpY2tzLmNvbS9ldmVyeXRoaW5nLW5lZWQta25vdy1jc3MtdmFyaWFibGVzLw&ntb=1) **📖**
-> - [animation | CSS-Tricks - CSS-Tricks](https://www.bing.com/ck/a?!&&p=1463c1cd792c3318JmltdHM9MTY5MjU3NjAwMCZpZ3VpZD0wNjRkM2JkYy0xMzkyLTY0ZDktMzA0MS0zNDRkMTJlZTY1NzUmaW5zaWQ9NTM0Mw&ptn=3&hsh=3&fclid=064d3bdc-1392-64d9-3041-344d12ee6575&psq=css+animations+article&u=a1aHR0cHM6Ly9jc3MtdHJpY2tzLmNvbS9hbG1hbmFjL3Byb3BlcnRpZXMvYS9hbmltYXRpb24v&ntb=1) **📖**
-> - [Flexbox CSS in 20 minutes](https://www.youtube.com/watch?v=JJSoEo8JSnc&list=PLillGF-RfqbZTASqIqdvm1R5mLrQq79CU&index=4&pp=iAQB) 🎥
-> - [CSS Grid Layout Crash Course](https://www.youtube.com/watch?v=jV8B24rSN5o&list=PLillGF-RfqbZTASqIqdvm1R5mLrQq79CU&index=5&pp=iAQB) 🎥
-
-<br/>
+Includes:
+- Week-by-week 5-week schedule
+- Full HTML & CSS assignment tables (with direct Elzero links)
+- Git & GitHub resources (Arabic + English)
+- Challenge platforms (Frontend Mentor, CSS Battle, etc.)
+- HTML & CSS interview prep
 
 ---
 
-<br/>
+### ⚙️ Phase 2 — Core Engineering
+> JavaScript, Algorithms, SASS, NPM & Tooling
 
-### D. HTML & CSS Practice
+��� **[View Phase 2 Roadmap →](./roadmap-02-core.md)**
 
-Learn to build and style web pages using HTML and CSS. Practice creating layouts, adding styles, and making your designs responsive and user-friendly.
-
-<br/>
-
-## 📺 Tutorials
-
-[**Elzero Web Schools**](https://elzero.org/practical-html-css/) [ Arabic ]
-> - [HTML AND CSS TEMPLATE 1](https://youtube.com/playlist?list=PLDoPjvoNmBAzHSjcR-HnW9tnxyuye8KbF) 🎥
-> - [HTML AND CSS TEMPLATE 2](https://youtube.com/playlist?list=PLDoPjvoNmBAy1l-2A21ng3gxEyocruT0t) 🎥
-> - [HTML AND CSS TEMPLATE 3](https://youtube.com/playlist?list=PLDoPjvoNmBAxuCSp2_-9LurPqRVwketnc) 🎥
-> - [HTML AND CSS TEMPLATE 4](https://youtube.com/playlist?list=PLDoPjvoNmBAyGaRGzPVZCkYx5L7Mo9Tbh) 🎥
-
-<br/>
-  
-[**Traversy Media**](https://www.youtube.com/@TraversyMedia) [ ENGLISH ]
-> - [Build a Starbucks Landing Page Clone](https://www.youtube.com/watch?v=x_n2FGNsm0o&list=PLillGF-RfqbZTASqIqdvm1R5mLrQq79CU&index=59&pp=iAQB) 🎥
-> - [Pluralsight Login Page Clone](https://www.youtube.com/watch?v=wIx1O5Y5EB4&list=PLillGF-RfqbZTASqIqdvm1R5mLrQq79CU&index=9&pp=iAQB) 🎥
-> - [Best Way to Create Nav](https://youtu.be/SkML640BcoA?si=x3zNG5r7PM-OO7B2) 🎥
-> - [Master responsive](https://youtu.be/x4u1yp3Msao?si=d_lRwpJcPTJsYzki) 🎥
-
-<br/>
-
-## 📚 Challenge Yourself
-> - [Frontend Mentor](https://www.frontendmentor.io/)
-> - [Code well](https://www.codewell.cc/challenges)
-> - [CSS Battle](https://cssbattle.dev/)
-> - [free templates](https://www.graphberry.com/)
-> - [Frontend Practice | Project Library](https://www.frontendpractice.com/projects)
-> - [Responsive Web Developer (devchallenges.io)](https://devchallenges.io/paths/responsive-web-developer)
-
-<br/>
-
-## 📚 Interview Questions
-> - [HTML INTERVIEW QUESTIONS](https://www.interviewbit.com/html-interview-questions/) 📖
-> - [CSS INTERVIEW QUESTIONS](https://www.interviewbit.com/css-interview-questions/) 📖
-
-<br/>
-
-## 📚 Interview Questions Videos
-> - [HTML INTERVIEW QUESTIONS](https://youtu.be/OGNcpEX5nvg?si=-PyDtspC4VGNMgo3) 🎥
-> - [CSS INTERVIEW QUESTIONS](https://youtu.be/CxhOM8O28rg?si=SDdnvjcToaoR_sY0) 🎥
-
-<br/>
+Includes:
+- 13-week intensive JS schedule
+- Full JS assignment tables for every week (with topic labels)
+- Bootstrap section with tutorials
+- SASS, NPM & Webpack modules
+- JS practice projects (Elzero, Unique Coderz, Traversy, Lama Dev)
+- Problem-solving platforms (LeetCode, NeetCode, JSchallenger)
+- JS interview prep
 
 ---
 
-<br/>
+### ⚛️ Phase 3 — Specialization
+> Choose your framework track
 
-### E. Basic Level Tasks
+Pick one path and master its full ecosystem:
 
-[Basic Tasks](https://www.notion.so/fff36d2c6e8d8174ac8ee9a678cbbf77?pvs=21)
-
-<br/>
-
----
-
-<br/>
-
-## 2. Intermediate
-
-### A.Bootstrap
-
-Bootstrap is a popular open-source CSS framework that provides pre-designed web elements and components for developers to use in their web projects. It was originally developed by Twitter and is now maintained by a community of developers. Bootstrap is designed to make it easy for developers to create responsive and mobile-first websites quickly and efficiently. It includes a wide range of pre-built CSS classes, JavaScript plugins, and other tools that can be used to create attractive and functional web interfaces without having to write much custom code.
-
-<br/>
-
-## Resources
-> [Bootstrap documentation](https://getbootstrap.com/)
-
-<br/>
-
-## Tutorials
-
-> - [Abdelrahman Gamal Bootstrap 4](https://www.youtube.com/watch?v=EzHbZjXDdKc&pp=ygUJYm9vdHN0cmFw)
-> - [Elzero Web School Bootstrap 5 Bondi Design](https://youtube.com/playlist?list=PLDoPjvoNmBAyvm7f--dc6XqkpfDcen_vQ)
-
-<br/>
+| React Ecosystem | Vue Ecosystem | Angular Ecosystem |
+|:---:|:---:|:---:|
+| ⚛️ **[React Path →](./roadmap-03-react.md)** | ��� **[Vue Path →](./roadmap-03-vue.md)** | ���️ **[Angular Path →](./roadmap-03-angular.md)** |
+| React · Redux · TypeScript · Next.js | Vue 3 · Pinia · Nuxt.js | Angular · RxJS · Dependency Injection |
 
 ---
 
-<br/>
+## ��� Learning Objectives
 
-### B. JavaScript
+By the end of this roadmap, students will be able to:
 
-JavaScript is a high-level programming language used to create interactive and dynamic websites. It is a scripting language that is used to create and control dynamic web content, such as animations and interactive forms. JavaScript is an essential component of modern web development and is supported by all major web browsers. It is often used in conjunction with HTML and CSS to create dynamic and responsive websites and web applications.
-
-<br/>
-
-## 📺 JavaScript Playlist
-
-[**Learn JavaScript 2021 In Arabic Elzero Web School**](https://youtube.com/playlist?list=PLDoPjvoNmBAx3kiplQR_oeDqLDBUDYwVv&si=_25JmcoETmXIaGyX)
-
-### Week 1
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 1 To 9 | Introduction | • [**Assignments For Lessons 1 To 9**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-001-to-009) |
-From 10 To 17 | Data Types | • [**Assignments For Lessons 10 To 17**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-010-to-017) |
-From 18 To 22 | Data Types | • [**Assignments For Lessons 18 To 22**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-018-to-022) |
-From 23 To 26 | Number & String | • [**Assignments For Lessons 23 To 26**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-023-to-026/) |
-From 27 To 30 | Number & String | • [**Assignments For Lessons 27 To 30**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-027-to-030/) |
-
-### Week 2
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 31 To 32 | Conditions | • [**Assignments For Lessons 31 To 32**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-031-to-032/) |
-From 33 To 37 | Conditions | • [**Assignments For Lessons 33 To 37**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-033-to-037/) |
-From 38 To 39 | Conditions | • [**Assignments For Lessons 38 To 39**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-038-to-039/) |
-From 40 To 47 | Array      | • [**Assignments For Lessons 40 To 47**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-040-to-047/) |
-From 48 To 53 | Loop       | • [**Assignments For Lessons 48 To 53**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-048-to-053/) |
-From 54 To 56 | Loop       | • [**Assignments For Lessons 54 To 56**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-054-to-056/) |
-
-### Week 3
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 57 To 63 | Functions | • [**Assignments For Lessons 57 To 63**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-057-to-063/) |
-From 64 To 70 | Functions | • [**Assignments For Lessons 64 To 70**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-064-to-070/) |
-
-### Week 4
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 71 To 78 | Higher Order Functions | • [**Assignments For Lessons 71 To 78**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-071-to-078/) |
-From 79 To 85 | Object | • [**Assignments For Lessons 79 To 85**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-079-to-085/) |
-
-### Week 5
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 86 To 93 | DOM | • [**Assignments For Lessons 86 To 93**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-086-to-093/) |
-From 94 To 101 | DOM | • [**Assignments For Lessons 94 To 101**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-094-to-101/) |
-
-Extra resource:
-
-- DOM Crash Course [Part #1 🎬](https://youtu.be/0ik6X4DJKCc) - [Part #2 🎬](https://youtu.be/mPd2aJXCZ2g) - [Part #3 🎬](https://youtu.be/wK2cBMcDTss) - [Part #4 (Final Project) 🎬](https://youtu.be/i37KVt_IcXw)
-
-### Week 6
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 102 To 110 | BOM | • [**Assignments For Lessons 102 To 110**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-102-to-110/) |
-From 111 To 114 | BOM | • [**Assignments For Lessons 111 To 114**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-111-to-114/) |
-
-### Week 7
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 115 To 122 | Destructuring | • [**Assignments For Lessons 115 To 122**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-115-to-122/) |
-
-### Week 8
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 123 To 133 | Map And Set | • [**Assignments For Lessons 123 To 133**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-123-to-133/) |
-
-### Week 9
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 134 To 146 | Regular Expression | • [**Assignments For Lessons 134 To 146**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-134-to-146/) |
-
-### Week 10
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 147 To 158 | OOP | • [**Assignments For Lessons 147 To 158**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-147-to-158/) |
-
-Extra resource:
-
-- [JavaScript OOP Crash Course (ES5 & ES6) 🎬](https://youtu.be/vDJpGenyHaA)
-
-### Week 11
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 159 To 168 | Date | • [**Assignments For Lessons 159 To 168**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-159-to-168/) |
-
-### Week 12
-| **Videos** | **Topic** | **Assignments Links** |
-| --- | --- | --- |
-From 169 To 178 | AJAX + JSON | • [**Assignments For Lessons 169 To 178**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-169-to-178/) |
-From 179 To 188 | Promise, Async, Await | • [**Assignments For Lessons 179 To 188**](https://elzero.org/javascript-bootcamp-assignments-lesson-from-179-to-188/) |
-
-<br/>
-
-## English [paid] [**jonas schmedtmann**]
-> - [**The Complete JavaScript Course 2023: From Zero to Expert!**](https://www.udemy.com/course/the-complete-javascript-course/) [recommended]
-
-<br/>
-
-## Resources
-> - **Follow the tutorial with an interactive environment** [**Learn JavaScript**](https://learnjavascript.online/)
-> - **The Modern JavaScript Tutorial [javascrip.info](https://javascript.info/)**
-
-<br/>
-
-## Youtube Channels
-> - [**Traversy Media**](https://www.youtube.com/channel/UC29ju8bIPH5as8OGnQzwJyA)
-> - [**Elzero Web School**](https://www.youtube.com/@ElzeroWebSchool)
-> - [**Freecodecamp**](https://www.youtube.com/@freecodecamp)
-> - [**Unique Coderz Academy**](https://www.youtube.com/@UniqueCoderzAcademy)
-
-<br/>
-
-## Interview Questions
-> - [**javascript-interview-questions**](https://github.com/FADL285/javascript-interview-questions) 
-
-<br/>
+- ✅ Build **responsive, accessible** websites from scratch using semantic HTML & modern CSS.
+- ✅ Write **clean, modular JavaScript** — including OOP, async patterns, and ES6+ features.
+- ✅ Work confidently with **Git, GitHub, NPM**, and professional developer tooling.
+- ✅ Solve algorithmic problems on **LeetCode** using JavaScript.
+- ✅ Build **production-grade applications** with a modern framework (React, Vue, or Angular).
+- ✅ Implement **state management, routing, API integration**, and authentication.
+- ✅ Deploy **fullstack applications** using Next.js, Nuxt, or Angular Universal.
 
 ---
 
-<br/>
+## ��� Setup
 
-### C. HTML CSS JavaScript Practice
+### Required Tools
+| Tool | Purpose | Download |
+|:---|:---|:---:|
+| Visual Studio Code | Code Editor | [Download](https://code.visualstudio.com/Download) |
+| Git | Version Control | [Download](https://git-scm.com/downloads) |
+| Node.js (LTS) | JavaScript Runtime & NPM | [Download](https://nodejs.org/) |
 
-<br/>
-
-## Resources
-
-- **Elzero Web School** [Front End Tutorials](https://youtube.com/playlist?list=PLDoPjvoNmBAycCXz5d9WvqlmykUIys5e8)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Create Image Slider**](https://youtu.be/QmPXb-RHy5s)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - To-Do App With Local Storage**](https://youtu.be/ylsFXMHpFUQ)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Create Countdown Timer**](https://youtu.be/eFsiOTJrrE8)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Memory Game**](https://youtu.be/KRj4DFBTBkA)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Create Hangman Game**](https://youtu.be/ZFb_eaYtWwY)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Fetch GitHub Repositories With Fetch API**](https://youtu.be/uCKCSO8vkiU)
-    > - [**[Arabic] HTML, CSS, JavaScript Tutorials - Create Quiz Application**](https://youtu.be/T5QyLcmcMJ4)
-    <br />
-    
-- **Unique coders** [here](https://www.youtube.com/@UniqueCoderzAcademy)
-    > - [**JavaScript Projects مشاريع وتطبيقات جافاسكربت**](https://youtube.com/playlist?list=PLtFbQRDJ11kGlRWp8MFhqlbO3ZmxIa3RE)
-    > - [**JS Project 2 [ Recipe App ]**](https://youtube.com/playlist?list=PLtFbQRDJ11kEMjSzhHKMdcIuLiIywYWjH)
-    > -  [**مشروع ادارة منتجات كامل بالجافاسكريبت | Full product management system crud with javascript**](https://youtu.be/nJZAvdUhUMs)
-    > - [**E-commerce ( Shopping Cart ) - Pure Javascript**](https://youtube.com/playlist?list=PLtFbQRDJ11kHCgyFid3khHdOk0VEHiJ3e) [Big Project]
-    <br />
-    
-- **Traversy Media**
-    > - [**Build 5 Projects With HTML, CSS & JavaScript**](https://youtu.be/JkeyKeK3V24)
-    > - [**Build a Netflix Landing Page Clone with HTML, CSS & JS**](https://youtu.be/P7t13SGytRk)
-    <br />
-    
-- **Lama Dev** [here](https://youtube.com/playlist?list=PLj-4DlPRT48lRNB0OYsK1WDCCryF1TQTN)
-    > - [**Create a Movie Website in 90 min. HTML & CSS & Javascript**](https://youtu.be/AOlkcLtyXkw)
-    > - [**HTML CSS Javascript E-commerce Website**](https://youtu.be/b3Gqq_k-g24)
-    <br/>
+### Recommended Accounts
+| Platform | Why |
+|:---|:---|
+| [GitHub](https://github.com/) | Code hosting & collaboration |
+| [LinkedIn](https://www.linkedin.com/) | Professional networking |
+| [LeetCode](https://leetcode.com/) | Problem-solving practice |
+| [Frontend Mentor](https://www.frontendmentor.io/) | Real-world UI challenges |
 
 ---
 
-<br/>
+## ✍️ Credits
 
-### D. SASS
-
-<br/>
-
-## What is SASS?
-
-> - **Sass** stands for **S**yntactically **A**wesome **S**tyle**s**heet
-> - Sass is an extension to CSS
-> - Sass is a CSS pre-processor
-> - Sass is completely compatible with all versions of CSS
-> - Sass reduces the repetition of CSS and therefore saves time
-> - Sass was designed by Hampton Catlin and developed by Natalie Weizenbaum in 2006
-
-<br/>
-
-
-## Why to use SASS?
-
-> - Stylesheets are getting larger, more complex, and harder to maintain. This is where a CSS pre-processor can help.
-> - Sass lets you use features that do not exist in CSS, like variables, nested rules, mixins, imports, inheritance, built-in functions, and other stuff
-
-<br/>
-
-
-## **How Does Sass Work?**
-
-> - A browser does not understand Sass code. Therefore, you will need a Sass pre-processor to convert Sass code into standard CSS.
-> - This process is called transpiling. So, you need to give a transpiler (some kind of program) some Sass code and then get some CSS code back.
-
-<br/>
-
-## Resources
-
-- **Arabic**
-    > - [**Learn SASS in Arabic [Elzero Web School]**](https://youtube.com/playlist?list=PLDoPjvoNmBAzlpyFHOaB3b-eubmF0TAV2&si=kTx6MER2hJ4kcyij)
-- **English**
-    > - [**SASS Tutorial [Net Ninja]**](https://youtube.com/playlist?list=PL4cUxeGkcC9jxJX7vojNVK-o8ubDZEcNb&si=EKzbriMx6_oyXoPB)
-    > - [**SASS Crash Course [Traversy Media]**](https://www.youtube.com/watch?v=nu5mdN2JIwM&pp=ygUKbGVhcm4gc2Fzcw%3D%3D)
-
-<br/>
+| Contributor | Role |
+|:---|:---|
+| **[Abdelrahman Ataa](https://github.com/abdelrahman-ops)** | Head of Frontend 2025–2026 · Roadmap Architect |
+| **Ameen Mohamed** | Vue.js Roadmap Contributor |
+| **Ihab Mahmoud** | Previous Frontend Head (2025 Roadmap) |
 
 ---
 
-<br/>
-
-### E. Problem-Solving
-
-## JSchallenger
-> - [Free Javascript challenges online | JSchallenger](https://www.jschallenger.com/)
-
-## freecodecamp
-> - [**JavaScript Algorithms and Data Structures**](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/)
-
-## Neet Code [problem-solving roadmap]
-> - [Roadmap (neetcode.io)](https://neetcode.io/roadmap)
-
-## Leet Code
-> - [Start with Easy problems, Medium, and so on](https://leetcode.com/)
-
-<br/>
-
----
-
-<br/>
-
-### F. NPM & Webpack
-
-## What is NPM?
-
->npm is the world's largest software registry. Open-source developers from every continent use npm to share and borrow packages, and many organizations use npm to manage private development as well.
-
-## Tutorial
-
-> - Traversy Media [NPM Crash Course](https://youtu.be/jHDhaSSKmB0?si=SIZj4D5QXvc5R4xC) 
-
-## What is Webpack?
-
-> Webpack is a **static module bundler for modern JavaScript applications**. It is an open-source tool that runs on top of NodeJS. Webpack takes modules with dependencies and generates one or more bundles that represent those modules. Webpack creates a dependency graph that maps every module your project needs and how they relate to each other.
-
-## Tutorial
-
-> - Traversy Media [Webpack5 Crash Course](https://youtu.be/IZGNcSuwBZs?si=xhKhBipya2elYllZ)
-
-<br/>
-
----
-
-<br/>
-
-### E. Intermediate Level Tasks
-[Intermediate Tasks](https://www.notion.so/TASKS-L2-fff36d2c6e8d818d8dd9d8b375a4b49c)
-
-<br/>
-
----
-
-<br/>
-
-## 3. Advanced Level
-
-### A. What before React js
-
-- HTML
-- CSS
-- JavaScript Fundamentals
-  > - Syntax
-  > - Variables
-  > - Arrays / Objects
-  > - Events
-  > - Functions
-  > - Loops
-  > - Conditions
-- High Order Array Methods
-   > - forEach
-   > - map
-   > - filter
-   > - reduce
-   > - sort
-- Arrow Function
-   > - Lexical “this keyword” How does it work?
-- Es6 Modules
-   > - import/export
-- Promises
-   > - Async/Await
-   > - Fetch API
-- Destructuring
-- Classes
-- Spread Operator
-- npm
-- Webpack & Babel
-    > - basic understanding and how they work
-
-<br/>
-
----
-
-<br/>
-
-### B. React js
-
-## Documentation
-> - [Official Documentation](https://react.dev/)
-
-<br/>
-
-## Arabic Tutorials
-- Kimz Codes
- > - [Part1: ReactJs Hooks 2023](https://www.youtube.com/watch?v=RgtTrM_sflo&list=PLejc1JbD4ZFSaQIFNstRIrbm_fqb12Q59&pp=iAQB)
- > - [Part2: LifeCycle](https://www.youtube.com/playlist?list=PLejc1JbD4ZFQa9YDF5pzB4JFbJovh3TN9)
- > - [Part3: Performance Optimization](https://www.youtube.com/watch?v=AZ41NpgebPA&list=PLejc1JbD4ZFTYdkjzqYBujf7UCVQyn_aq&pp=iAQB)
- > - [Part4: ReactJs Advanced](https://www.youtube.com/watch?v=aC9vgsUorPE&list=PLejc1JbD4ZFTiDCCVu_uCW0GXqyvhtbf8&pp=iAQB)
-
-
-- Code Zone
- > - [**Arabic React Course [Itrax] - كورس ريأكت بالعربى**](https://youtube.com/playlist?list=PLQtNtS-WfRa9LbmD8ON7rWhn-AtKTGdkn&si=dtxIyDWEhVg4HoFe)
-
-<br/>
-
-## English Tutorials
-- freecodecamp
- > - [React Course - Beginner's Tutorial for React JavaScript Library [2022]](https://www.youtube.com/watch?v=bMknfKXIFA8&t=2s)
-
-- Jonas Schmedtmann [Recommended] [Paid]
- > - [The Ultimate React Course 2023: React, Redux & More](https://www.udemy.com/course/the-ultimate-react-course/)
-
-- Maximilian Schwarzmüller [Paid]
- > - [React - The Complete Guide 2023 (incl. React Router & Redux)](https://www.udemy.com/course/react-the-complete-guide-incl-redux/)
-
-<br/>
-
----
-
-<br/>
-
-### C. React Practice
-
-## Beginner
-> - [**Brand page**](https://youtu.be/W7up-w1QYpw?si=ZKItS1GRplcWPnLz)
-> - [**Contact Us page**](https://www.youtube.com/watch?v=hrHIzqyq06U)
-> - [**Foody Zone**](https://youtu.be/i__4ul5yXFc?si=OezvNqrEvlgyBf9J)
-> - [**React Todo List App**](https://www.youtube.com/watch?v=LoYbN6qoQHA)
-
-<br/>
-
-## Beginner to Intermediate
-> - [**Invoice App in ReactJs**](https://youtube.com/playlist?list=PLakmP0ibjfQcNNh7PnmIQ9zTm2bLM_wCC&si=YVW0WZCN2AvfKU9G)
-
-<br/>
-
-## Advanced
-> - [**Build App Clones with ReactJS**](https://youtube.com/playlist?list=PL-J2q3Ga50oMQa1JdSJxYoZELwOJAXExP&si=VO45dYjcXI9pc5gy)
-
-<br/>
-
-## Youtube Channels
-
-> - [(23) JavaScript Mastery - YouTube](https://www.youtube.com/@javascriptmastery)
-> - [(23) Traversy Media - YouTube](https://www.youtube.com/@TraversyMedia)
-> - [(23) Lama Dev - YouTube](https://www.youtube.com/@LamaDev)
-> - [freeCodeCamp.org - YouTube](https://www.youtube.com/@freecodecamp)
-
-<br/>
-
----
-
-<br/>
-
-### D. Redux
-
-Redux Toolkit is a powerful library that simplifies state management in Redux applications. It provides tools for writing cleaner and more efficient Redux code by offering features like a simplified store setup, built-in reducers, actions, and middleware. It also helps reduce boilerplate and improves developer productivity, making it easier to manage global state in React apps.
-
-## Documentation
-> - [Official Documentation](https://redux.js.org/)
-
-<br/>
-
-## Arabic Tutorials
-- Kimz Codes 
-  > - [**React Level 2 Part 1: Redux ToolKit**](https://youtube.com/playlist?list=PLejc1JbD4ZFREfrBoSl8tjAPZOY6HNqZv&si=3W2ITXcvVxsYbNSw)
-  > - [React Level 2 - Part 2: Redux ToolKit Build Book Store](https://youtube.com/playlist?list=PLejc1JbD4ZFQFvS469VXyCPO_py_kvVD5&si=RnaU1qoCr0HteypV)
-
-- Index Academy - اتعلم برمجة بالعربي
-  > - [Redux With React](https://youtube.com/playlist?list=PLDQ11FgmbqQObr_XGBVQiRr89YitNq-zc&si=jdm9bdzeq3vGxCSV)
-
-<br/>
-
-## English Tutorials 
-- freeCodeCamp
-  > - [Redux Tutorial - Beginner to Advanced](https://youtu.be/zrs7u6bdbUw?si=7bFF43-Pyjjnzun-)
-
-- Jonas Schmedtmann [Recommended] [Paid]
-    > - [The Ultimate React Course 2023: React, Redux & More](https://www.udemy.com/course/the-ultimate-react-course/)
-
-- Maximilian Schwarzmüller [Paid]  
-    > - [React - The Complete Guide 2023 (incl. React Router & Redux)](https://www.udemy.com/course/react-the-complete-guide-incl-redux/)
-
-<br/>
-
----
-
-<br/>
-
-### E. Tailwind CSS
-
-## Tutorials
-
-- Ag Coding
-    > - [**Tailwind CSS**](https://youtube.com/playlist?list=PLnD96kXp-_pMR9cBUmvsz_kIIt9bv2UIP&si=vv0FzQALeH1D3USo)
-    
-- أكاديمية ترميز
-  > - [تعلم Tailwind CSS في مقطع واحد](https://youtu.be/Pk3hhCJG2Dk?si=QWscffc5F9Dx9uJa)
-    
-<br />
-
-## Practice
-
-- Light Code
-    > - [Build and Deploy a Fully Responsive Plant Website](https://youtu.be/zKguO4oaAGs?si=fKNO__W54_s32q3i)
-- Nour Homsi
-    > - [Full Website Using Tailwind](https://youtu.be/9Px2cwdQ8PM?si=bl2qzwOweTRLqc6O)
-
-<br/>
-
----
-
-<br/>
-
-### F. TypeScript
-
-## What is TypeScript?
-
-- TypeScript is a syntactic superset of JavaScript which adds **static typing**.
-    - "Syntactic Superset" means that it shares the same base syntax as JavaScript but adds something to it.
-- This basically means that TypeScript adds syntax on top of JavaScript, allowing developers to add **types**.
-
-<br />
-
-## Why should I use TypeScript?
-
-- JavaScript is a loosely typed language. It can be difficult to understand what types of data are being passed around in JavaScript.
-- In JavaScript, function parameters and variables don't have any information! So developers need to look at documentation or guess based on the implementation.
-- TypeScript allows specifying the types of data being passed around within the code and has the ability to report errors when the types don't match.
-- For example, TypeScript will report an error when passing a string into a function that expects a number. JavaScript will not.
-
-<br />
-
-## Resources
-- Arabic
-    > - [Learn TypeScript In Arabic [Elzero Web School]](https://www.youtube.com/watch?v=yUndnE-2osg&list=PLDoPjvoNmBAy532K9M_fjiAmrJ0gkCyLJ)
-
-- English
-    > - [Learn TypeScript In English [Net Ninja]](https://www.youtube.com/watch?v=2pZmKW9-I_k&list=PL4cUxeGkcC9gUgr39Q_yD6v-bSyMwKPUI)
-    > - [TypeScript Crash Course for React/Nextjs developers [Lama Dev]](https://www.youtube.com/watch?v=WlxcujsvcIY&pp=ygUTdHlwZXNjcmlwdCB0dXRvcmlhbA%3D%3D)
-
-<br/>
-
----
-
-<br/>
-
-### G. React + TypeScript
-
-## Projects
-  > - [Build eCommerce App using React, TypeScript and Redux Toolkit](https://youtube.com/playlist?list=PLejc1JbD4ZFS4sEpIpLfD18FEnEpafVbz&si=13x7be8x1J7bdEV5)
-
-<br/>
-
----
-
-<br/>
-
-### I. React Extra libraries
-
-<br/>
-
-## Navigation
-  > - [React Router Tutorial](https://youtube.com/playlist?list=PLC3y8-rFHvwjkxt8TOteFdT_YmzwpBlrG&si=2Wbb0w3RpTcCkFVG)
-  > - [React Router - Complete Tutorial](https://youtu.be/oTIJunBa6MA?si=RoUyTVVPcjEdQnUI) 
-
-<br/>
-
-## UI Libraries
-  > - [Material UI Tutorial](https://youtube.com/playlist?list=PL4cUxeGkcC9gjxLvV4VEkZ6H6H4yWuS58&si=3ptZuUcr8US2Y5K4)
-  > - [Shadcn UI Tutorial](https://youtube.com/playlist?list=PL4cUxeGkcC9h1NXLUuiAQ7c4UtdEInqma&si=zsYuHSPPITijt_4o)
-
-<br/>
-
-## Data Fetching
- > - [Learn React Query In 50 Minutes](https://youtu.be/r8Dg0KVnfMA?si=5DlWRpnhHyvz35Od)
- > - [React Query - Complete Tutorial](https://youtu.be/8K1N3fE-cDs?si=jbuDOUcGgU2UomK5)
-
-<br/>
-
-## Form Validation
- > - [React Hook Form: Crash Course](https://youtu.be/8OO4xhJnniU?si=8FTADKTdlmQM0y8U) (Arabic)
- > - [Learn Zod In 30 Minutes](https://youtu.be/L6BE-U3oy80?si=T6shH27dz5YqGWSY)
- > - [React Hook Form - Complete Tutorial (with Zod)](https://youtu.be/cc_xmawJ8Kg?si=2vsSvcVpAAniV2lg)
- > - [React Hook Form Tutorials](https://youtube.com/playlist?list=PLC3y8-rFHvwjmgBr1327BA5bVXoQH-w5s&si=6oi5HpmVqw9nfTNS)
-
-<br/>
-
----
-
-<br/>
-
-### I. Next JS
-
-Next.js is a React framework that enables server-side rendering (SSR) and static site generation (SSG) for building fast, optimized web applications. It offers features like file-based routing, API routes, automatic code splitting, and easy deployment, making it a popular choice for building scalable, SEO-friendly websites with excellent performance.
-
-## Documentation
-> - [Official Documentation](https://nextjs.org/)
-
-<br />
-
-
-## Arabic Tutorials
-
-- أكاديمية ترميز
-  > - [كورس NEXT JS | شرح كامل في ساعتين | شرح نظري و تطبيق عملي | SSG vs SSR vs ISG vs SPA](https://youtu.be/_t4c-vxalp4?si=jipE9elCYlxJ2Dx2)
-  
-- Index Academy - اتعلم برمجة بالعربي
-  > - [‎⁨NextJS 13- Course](https://youtu.be/KN66vLV0QZk?si=jgyJDHY9IeJ1y6HY)
-
-<br />
-
-## English Tutorials
-- JavaScript Mastery
-    > - [**Next.js 14 Full Course 2024**](https://youtu.be/wm5gMKuwSYk?si=B2SscjZRC-07Ouyj)
-
-- Stephen Grider [Recommended] [Paid]
-  > - [Next JS: The Complete Developer's Guide](https://www.udemy.com/course/next-js-the-complete-developers-guide/?couponCode=OF83024E)
-
-- Maximilian Schwarzmüller [Paid]
-  > - [Next.js 14 & React - The Complete Guide](https://www.udemy.com/course/nextjs-react-the-complete-guide/?couponCode=OF83024E)
-
-<br />
-
----
-
-<br />
-
-### Credit
-- [Ihab Mahmoud - Circle Head](www.linkedin.com/in/ihabmahmoud1)
-
+<p align="center">
+  <strong>CAT Reloaded — Frontend Circle © 2026</strong><br/>
+  <em>Built with discipline. Shipped with pride.</em>
+</p>

--- a/Front End/roadmap-01-foundation.md
+++ b/Front End/roadmap-01-foundation.md
@@ -1,0 +1,194 @@
+# Phase 1: The Foundation
+*Goal: Build static pages that look great and follow best practices.*
+
+> **"Front-end development is not just about code; it's about crafting experiences."**
+
+---
+
+## Prerequisites & Setup
+
+### **Tools**
+| Tool | Purpose | Download |
+|:---|:---|:---:|
+| Visual Studio Code | Code Editor | [Download](https://code.visualstudio.com/Download) |
+| Git | Version Control | [Download](https://git-scm.com/downloads) |
+
+### **Accounts to Create**
+| Platform | Why |
+|:---|:---|
+| [GitHub](https://github.com/) | Code hosting & collaboration |
+| [LinkedIn](https://www.linkedin.com/) | Professional networking |
+| [LeetCode](https://leetcode.com/) | Problem-solving practice |
+
+---
+
+## The 5-Week Schedule
+
+### **Week 1: The Setup & Syntax**
+**Goal:** Learn how the web works and master semantic HTML.
+*   **Study:**
+    *   **Introduction: The Invisible Web**
+        > - [How does the Internet work?](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/How_does_the_Internet_work)
+        > - [World Wide Web (WWW) Basic Mechanics](https://frontendmasters.com/guides/learning-roadmap/www-basic-mechanics/)
+        > - [An Overview of HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview)
+        > - [How The Web Works](https://academind.com/tutorials/how-the-web-works)
+        > - [What is a web browser?](https://www.mozilla.org/en-US/firefox/browsers/what-is-a-browser/)
+        > - [How Browsers Work](https://www.freecodecamp.org/news/web-application-security-understanding-the-browser-5305ed2f1dac/)
+        > - [What is DNS?](https://aws.amazon.com/route53/what-is-dns/)
+        > - [What is a domain name?](https://www.cloudflare.com/learning/dns/glossary/what-is-a-domain-name/)
+    *   **[HTML Playlist — Elzero Web School](https://youtube.com/playlist?list=PLDoPjvoNmBAw_t_XWUFbBX-c9MafPk9ji)**
+*   **Practice:**
+    *   Create a purely HTML Resume.
+    *   Use tables, lists, and semantic tags.
+
+#### HTML Assignments
+
+| Videos | # Assignments | Link |
+|:---|:---:|:---|
+| 1 → 5 | 4 | [Assignments 01–05](https://elzero.org/html-assignments-lesson-from-1-to-5/) |
+| 6 → 10 | 7 | [Assignments 06–10](https://elzero.org/html-assignments-lesson-from-6-to-10/) |
+| 11 → 14 | 4 | [Assignments 11–14](https://elzero.org/html-assignments-lesson-from-11-to-14/) |
+| 15 → 18 | 3 | [Assignments 15–18](https://elzero.org/html-assignments-lesson-from-15-to-18/) |
+| 19 → 23 | 4 | [Assignments 19–23](https://elzero.org/html-assignments-lesson-from-19-to-23/) |
+| 24 → 27 | 2 | [Assignments 24–27](https://elzero.org/html-assignments-lesson-from-24-to-27/) |
+| 28 → 30 | 3 | [Assignments 28–30](https://elzero.org/html-assignments-lesson-from-28-to-30/) |
+| 31 → 34 | 4 | [Assignments 31–34](https://elzero.org/html-assignments-lesson-from-31-to-34/) |
+| 35 → 37 | 2 | [Assignments 35–37](https://elzero.org/html-assignments-lesson-from-35-to-37/) |
+
+---
+
+### **Week 2: CSS Basics**
+**Goal:** Understand the Box Model, Colors, and Fonts.
+*   **Study:**
+    *   **[CSS Playlist — Elzero Web School (Lessons 1–53)](https://youtube.com/playlist?list=PLDoPjvoNmBAzjsz06gkzlSrlev53MGIKe)**
+*   **Practice:**
+    *   Implement basic photo layouts using HTML/CSS.
+
+#### CSS Assignments — Week 2
+
+| Videos | # Assignments | Link |
+|:---|:---:|:---|
+| 01 → 04 | 6 | [Assignments 01–04](https://elzero.org/css-assignments-lesson-from-1-to-4/) |
+| 05 → 08 | 4 | [Assignments 05–08](https://elzero.org/css-assignments-lesson-from-5-to-8/) |
+| 09 → 12 | 2 | [Assignments 09–12](https://elzero.org/css-assignments-lesson-from-9-to-12/) |
+| 13 → 16 | 2 | [Assignments 13–16](https://elzero.org/css-assignments-lesson-from-13-to-16/) |
+| 17 → 21 | 4 | [Assignments 17–21](https://elzero.org/css-assignments-lesson-from-17-to-21/) |
+| 22 → 26 | 3 | [Assignments 22–26](https://elzero.org/css-assignments-lesson-from-22-to-26/) |
+| 27 → 29 | 2 | [Assignments 27–29](https://elzero.org/css-assignments-lesson-from-27-to-29/) |
+| 30 → 33 | 4 | [Assignments 30–33](https://elzero.org/css-assignments-lesson-from-30-to-33/) |
+| 34 → 37 | 4 | [Assignments 34–37](https://elzero.org/css-assignments-lesson-from-34-to-37) |
+| 38 → 41 | 3 | [Assignments 38–41](https://elzero.org/css-assignments-lesson-from-38-to-41/) |
+| 42 → 45 | 3 | [Assignments 42–45](https://elzero.org/css-assignments-lesson-from-42-to-45/) |
+| 46 → 53 | 6 | [Assignments 46–53](https://elzero.org/css-assignments-lesson-from-46-to-53/) |
+
+---
+
+### **Week 3: Visual Effects**
+**Goal:** Mastering Positioning, Backgrounds, and Transitions.
+*   **Study:**
+    *   **[CSS Playlist (Lessons 54–67)](https://youtube.com/playlist?list=PLDoPjvoNmBAzjsz06gkzlSrlev53MGIKe)**
+*   **Practice:**
+    *   Recreate complex visual cards.
+
+#### CSS Assignments — Week 3
+
+| Videos | # Assignments | Link |
+|:---|:---:|:---|
+| 54 → 56 | 2 | [Assignments 54–56](https://elzero.org/css-assignments-lesson-from-54-to-56/) |
+| 57 → 64 | 6 | [Assignments 57–64](https://elzero.org/css-assignments-lesson-from-57-to-64/) |
+| 65 → 67 | 3 | [Assignments 65–67](https://elzero.org/css-assignments-lesson-from-65-to-67/) |
+
+---
+
+### **Week 4: Layout Mastery**
+**Goal:** Flexbox & Grid. This is how real websites are built.
+*   **Study:**
+    *   **[CSS Playlist (Lessons 68–88)](https://youtube.com/playlist?list=PLDoPjvoNmBAzjsz06gkzlSrlev53MGIKe)**
+
+#### CSS Assignments — Week 4
+
+| Videos | # Assignments | Link |
+|:---|:---:|:---|
+| 68 → 73 | 5 | [Assignments 68–73](https://elzero.org/css-assignments-lesson-from-68-to-73/) |
+| 74 → 77 | 4 | [Assignments 74–77](https://elzero.org/css-assignments-lesson-from-74-to-77/) |
+| 78 → 82 | 8 | [Assignments 78–82](https://elzero.org/css-assignments-lesson-from-78-to-82/) |
+| 83 → 85 | 3 | [Assignments 83–85](https://elzero.org/css-assignments-lesson-from-83-to-85/) |
+| 86 → 88 | 2 | [Assignments 86–88](https://elzero.org/css-assignments-lesson-from-86-to-88/) |
+
+*   **Reference Articles:**
+    *   **[A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)**
+    *   **[A Complete Guide to CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)**
+    *   **[CSS Positioning](https://css-tricks.com/almanac/properties/p/position/)**
+    *   **[Everything about CSS Variables](https://css-tricks.com/everything-need-know-css-variables/)**
+    *   **[CSS Animations](https://css-tricks.com/almanac/properties/a/animation/)**
+    *   **[Flexbox CSS in 20 Minutes](https://www.youtube.com/watch?v=JJSoEo8JSnc)**
+    *   **[CSS Grid Layout Crash Course](https://www.youtube.com/watch?v=jV8B24rSN5o)**
+
+---
+
+### **Week 5: The Final Boss**
+**Goal:** Full Template Integration.
+*   **Projects:**
+    *   [HTML/CSS Template 1](https://youtube.com/playlist?list=PLDoPjvoNmBAzHSjcR-HnW9tnxyuye8KbF)
+    *   [HTML/CSS Template 2](https://youtube.com/playlist?list=PLDoPjvoNmBAy1l-2A21ng3gxEyocruT0t)
+
+*   **Extra Practice (Traversy Media):**
+    *  [Build a Starbucks Landing Page Clone](https://www.youtube.com/watch?v=x_n2FGNsm0o)
+    *   **[Pluralsight Login Page Clone](https://www.youtube.com/watch?v=wIx1O5Y5EB4)**
+    *   **[Best Way to Create Nav](https://youtu.be/SkML640BcoA)**
+    *   **[Master Responsive Design](https://youtu.be/x4u1yp3Msao)**
+
+---
+
+## ️ Challenge Yourself
+
+> Practice beyond the curriculum. These platforms provide real-world design challenges.
+
+| Platform | Focus |
+|:---|:---|
+| [Frontend Mentor](https://www.frontendmentor.io/) | Professional UI Challenges |
+| [Codewell](https://www.codewell.cc/challenges) | Free Design-to-Code |
+| [CSS Battle](https://cssbattle.dev/) | CSS Problem-Solving |
+| [Frontend Practice](https://www.frontendpractice.com/projects) | Clone Real Websites |
+| [Graphberry Templates](https://www.graphberry.com/) | Free Templates to Implement |
+| [Responsive Web Developer](https://devchallenges.io/paths/responsive-web-developer) | Progressive Challenges |
+
+---
+
+## ️ Essential Resources
+
+### **Git & GitHub**
+| Resource | Type |
+|:---|:---:|
+| [Elzero Git Course](https://www.youtube.com/playlist?list=PLDoPjvoNmBAw4eOj58MZPakHjaO3frVMF) |  Arabic |
+| [Algorithm Academy — Git](https://www.youtube.com/playlist?list=PLfDx4cQoUNOYVfQs_NFNyykcqkaJ_plmK) |  Arabic |
+| [Git & GitHub — شخبط وانت متطمن](https://www.youtube.com/watch?v=Q6G-J54vgKc) |  Recommended |
+| [Git Official Book](https://git-scm.com/book/en/v2) |  English |
+| [Git Cheat Sheet](https://github.com/FADL285/git-cheat-sheet) |  Reference |
+| [GitHub Hello World Guide](https://guides.github.com/activities/hello-world/) |  English |
+
+### **HTML**
+| Resource | Type |
+|:---|:---:|
+| [HTML Tutorial — W3Schools](https://www.w3schools.com/html/default.asp) |  |
+| [HTML Basics — MDN Web Docs](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics) |  |
+
+### **CSS**
+| Resource | Type |
+|:---|:---:|
+| [Learn CSS — web.dev](https://web.dev/learn/css/) |  |
+| [CSS Tutorial — W3Schools](https://www.w3schools.com/Css/) |  |
+| [MDN CSS Reference](https://developer.mozilla.org/en-US/docs/Web/CSS) |  |
+
+---
+
+## ️ Interview Prep
+
+> Prepare for technical interviews even at this stage.
+
+| Topic | Resource | Type |
+|:---|:---|:---:|
+| HTML | [HTML Interview Questions](https://www.interviewbit.com/html-interview-questions/) |  |
+| HTML | [HTML Interview Video](https://youtu.be/OGNcpEX5nvg) |  |
+| CSS | [CSS Interview Questions](https://www.interviewbit.com/css-interview-questions/) |  |
+| CSS | [CSS Interview Video](https://youtu.be/CxhOM8O28rg) |  |

--- a/Front End/roadmap-02-core.md
+++ b/Front End/roadmap-02-core.md
@@ -1,0 +1,271 @@
+# ⚙️ Phase 2: Core Engineering
+*Goal: Master JavaScript, Algorithms, and Professional Tooling.*
+
+> **"Amateurs call it coding. Professionals call it Engineering."**
+
+This is a **13-Week Intensive Sprint** designed to turn you into a problem solver.
+
+---
+
+##  Module A: Logic & Layouts (Weeks 1-4)
+
+###  Week 1: Syntax & Layouts
+*   **JS Study:** [Elzero JS (Videos 1–30)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Variables, Data Types, Operators.
+*   **Visual Task:** [HTML/CSS Template 3](https://youtube.com/playlist?list=PLDoPjvoNmBAxuCSp2_-9LurPqRVwketnc).
+
+####  JS Assignments — Week 1
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 1 → 9 | Introduction | [Assignments 001–009](https://elzero.org/javascript-bootcamp-assignments-lesson-from-001-to-009) |
+| 10 → 17 | Data Types | [Assignments 010–017](https://elzero.org/javascript-bootcamp-assignments-lesson-from-010-to-017) |
+| 18 → 22 | Data Types | [Assignments 018–022](https://elzero.org/javascript-bootcamp-assignments-lesson-from-018-to-022) |
+| 23 → 26 | Number & String | [Assignments 023–026](https://elzero.org/javascript-bootcamp-assignments-lesson-from-023-to-026/) |
+| 27 → 30 | Number & String | [Assignments 027–030](https://elzero.org/javascript-bootcamp-assignments-lesson-from-027-to-030/) |
+
+---
+
+###  Week 2: Control Flow & Cloning
+*   **JS Study:** [Elzero JS (Videos 31–56)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Conditions, Loops, Arrays.
+*   **Visual Task:** [Starbucks Landing Page Clone](https://www.youtube.com/watch?v=x_n2FGNsm0o).
+
+####  JS Assignments — Week 2
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 31 → 32 | Conditions | [Assignments 031–032](https://elzero.org/javascript-bootcamp-assignments-lesson-from-031-to-032/) |
+| 33 → 37 | Conditions | [Assignments 033–037](https://elzero.org/javascript-bootcamp-assignments-lesson-from-033-to-037/) |
+| 38 → 39 | Conditions | [Assignments 038–039](https://elzero.org/javascript-bootcamp-assignments-lesson-from-038-to-039/) |
+| 40 → 47 | Arrays | [Assignments 040–047](https://elzero.org/javascript-bootcamp-assignments-lesson-from-040-to-047/) |
+| 48 → 53 | Loops | [Assignments 048–053](https://elzero.org/javascript-bootcamp-assignments-lesson-from-048-to-053/) |
+| 54 → 56 | Loops | [Assignments 054–056](https://elzero.org/javascript-bootcamp-assignments-lesson-from-054-to-056/) |
+
+---
+
+###  Week 3: Functions & Forms
+*   **JS Study:** [Elzero JS (Videos 57–70)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Functions, Scopes.
+*   **Visual Task 1:** [Pluralsight Login Page Clone](https://www.youtube.com/watch?v=wIx1O5Y5EB4).
+*   **Visual Task 2:** Start [HTML/CSS Template 4](https://youtube.com/playlist?list=PLDoPjvoNmBAyGaRGzPVZCkYx5L7Mo9Tbh).
+
+####  JS Assignments — Week 3
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 57 → 63 | Functions | [Assignments 057–063](https://elzero.org/javascript-bootcamp-assignments-lesson-from-057-to-063/) |
+| 64 → 70 | Functions | [Assignments 064–070](https://elzero.org/javascript-bootcamp-assignments-lesson-from-064-to-070/) |
+
+---
+
+###  Week 4: Higher Order Logic
+*   **JS Study:** [Elzero JS (Videos 71–85)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Map, Filter, Reduce.
+*   **Drill:** LeetCode "Array" problems.
+*   **Visual Task:** Finish Template 4.
+
+####  JS Assignments — Week 4
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 71 → 78 | Higher Order Functions | [Assignments 071–078](https://elzero.org/javascript-bootcamp-assignments-lesson-from-071-to-078/) |
+| 79 → 85 | Objects | [Assignments 079–085](https://elzero.org/javascript-bootcamp-assignments-lesson-from-079-to-085/) |
+
+---
+
+## ⚡ Module B: DOM & Interactivity (Weeks 5-7)
+
+###  Week 5: DOM & Bootstrap
+*   **JS Study:** [Elzero JS (Videos 86–101)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — DOM, Events.
+*   **Framework:** [Bootstrap 5 Documentation](https://getbootstrap.com/)
+*   **Bootstrap Tutorials:**
+    *    [Abdelrahman Gamal — Bootstrap 4](https://www.youtube.com/watch?v=EzHbZjXDdKc)
+    *    [Elzero — Bootstrap 5 Bondi Design](https://youtube.com/playlist?list=PLDoPjvoNmBAyvm7f--dc6XqkpfDcen_vQ)
+*   **Project:** Build a Responsive Landing Page using Bootstrap.
+
+####  JS Assignments — Week 5
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 86 → 93 | DOM | [Assignments 086–093](https://elzero.org/javascript-bootcamp-assignments-lesson-from-086-to-093/) |
+| 94 → 101 | DOM | [Assignments 094–101](https://elzero.org/javascript-bootcamp-assignments-lesson-from-094-to-101/) |
+
+*   **Extra:** DOM Crash Course — [Part 1](https://youtu.be/0ik6X4DJKCc) · [Part 2](https://youtu.be/mPd2aJXCZ2g) · [Part 3](https://youtu.be/wK2cBMcDTss) · [Part 4 (Project)](https://youtu.be/i37KVt_IcXw)
+
+---
+
+###  Week 6: Persistent Data (BOM)
+*   **JS Study:** [Elzero JS (Videos 102–114)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — LocalStorage, BOM.
+*   **Project:** [Todo List V2 (Persistent)](https://youtu.be/ylsFXMHpFUQ).
+
+####  JS Assignments — Week 6
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 102 → 110 | BOM | [Assignments 102–110](https://elzero.org/javascript-bootcamp-assignments-lesson-from-102-to-110/) |
+| 111 → 114 | BOM | [Assignments 111–114](https://elzero.org/javascript-bootcamp-assignments-lesson-from-111-to-114/) |
+
+---
+
+###  Week 7: Advanced Data & Regex
+*   **JS Study:** [Elzero JS (Videos 115–133)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Destructuring, Sets, Maps.
+*   **Project 1:** [Countdown Timer](https://youtu.be/eFsiOTJrrE8).
+*   **Project 2:** [Netflix Landing Page Clone](https://youtu.be/P7t13SGytRk).
+
+####  JS Assignments — Week 7
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 115 → 122 | Destructuring | [Assignments 115–122](https://elzero.org/javascript-bootcamp-assignments-lesson-from-115-to-122/) |
+| 123 → 133 | Map & Set | [Assignments 123–133](https://elzero.org/javascript-bootcamp-assignments-lesson-from-123-to-133/) |
+
+---
+
+##  Module C: Advanced Engineering (Weeks 8-10)
+
+###  Week 8: Data Patterns & Regex
+*   **JS Study:** [Elzero JS (Videos 134–146)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Regex, Modules.
+*   **Project:** Validation Form System.
+
+####  JS Assignments — Week 8
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 134 → 146 | Regular Expressions | [Assignments 134–146](https://elzero.org/javascript-bootcamp-assignments-lesson-from-134-to-146/) |
+
+---
+
+###  Week 9: OOP
+*   **JS Study:** [Elzero JS (Videos 147–168)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Classes, Prototypes.
+*   **Project 1:** [Quiz App (OOP)](https://youtu.be/T5QyLcmcMJ4).
+*   **Project 2:** [Product Management System (CRUD)](https://youtu.be/nJZAvdUhUMs).
+
+####  JS Assignments — Week 9
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 147 → 158 | OOP | [Assignments 147–158](https://elzero.org/javascript-bootcamp-assignments-lesson-from-147-to-158/) |
+| 159 → 168 | Date & Time | [Assignments 159–168](https://elzero.org/javascript-bootcamp-assignments-lesson-from-159-to-168/) |
+
+*   **Extra:**  [JavaScript OOP Crash Course (ES5 & ES6)](https://youtu.be/vDJpGenyHaA)
+
+---
+
+###  Week 10: Async & API
+*   **JS Study:** [Elzero JS (Videos 169–188)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAx3kiplXPkLUq0o57XMW8y_) — Promises, Fetch.
+*   **Project:** [GitHub Repo Fetcher](https://youtu.be/uCKCSO8vkiU).
+
+####  JS Assignments — Week 10
+
+| Videos | Topic | Link |
+|:---|:---|:---|
+| 169 → 178 | AJAX & JSON | [Assignments 169–178](https://elzero.org/javascript-bootcamp-assignments-lesson-from-169-to-178/) |
+| 179 → 188 | Promises, Async/Await | [Assignments 179–188](https://elzero.org/javascript-bootcamp-assignments-lesson-from-179-to-188/) |
+
+---
+
+## ️ Module D: Pro Tooling (Weeks 11-13)
+
+###  Week 11: SASS
+
+> **Sass** (Syntactically Awesome Stylesheets) is a CSS pre-processor that adds variables, nested rules, mixins, imports, and built-in functions — reducing repetition and saving time.
+
+*   **Arabic:** [Elzero SASS Playlist](https://www.youtube.com/playlist?list=PLDoPjvoNmBAzlPyLCtVVMNqaAFxCIY7ii)
+*   **English:** [SASS Tutorial — Net Ninja](https://youtube.com/playlist?list=PL4cUxeGkcC9jxJX7vojNVK-o8ubDZEcNb)
+*   **English:** [SASS Crash Course — Traversy Media](https://www.youtube.com/watch?v=nu5mdN2JIwM)
+*   **Mission:** Refactor Netflix Clone CSS to SASS.
+
+---
+
+###  Week 12: Tooling (NPM & Git)
+
+#### What is NPM?
+> npm is the world's largest software registry. Open-source developers use it to share and borrow packages, and organizations use it to manage private development.
+
+#### What is Webpack?
+> Webpack is a static module bundler for modern JavaScript applications. It creates a dependency graph and generates optimized bundles for production.
+
+*    [NPM Crash Course — Traversy Media](https://youtu.be/jHDhaSSKmB0)
+*    [Webpack 5 Crash Course — Traversy Media](https://youtu.be/IZGNcSuwBZs)
+*   **Task:** Set up a professional local environment with scripts.
+
+---
+
+###  Week 13: THE CAPSTONE
+*   **Project:** **[Vanilla JS E-Commerce System](https://youtu.be/b3Gqq_k-g24)**
+    *   **Features:** Cart, Favorites, Category Filter.
+    *   **Tech:** Class-based JS, SASS, NPM.
+
+---
+
+## ️ JS Practice Projects
+
+> Build these alongside the weekly schedule to reinforce concepts.
+
+### **Elzero Web School** (Arabic)
+| Project | Link |
+|:---|:---|
+| Image Slider | [Tutorial](https://youtu.be/QmPXb-RHy5s) |
+| To-Do App (LocalStorage) | [Tutorial](https://youtu.be/ylsFXMHpFUQ) |
+| Countdown Timer | [Tutorial](https://youtu.be/eFsiOTJrrE8) |
+| Memory Game | [Tutorial](https://youtu.be/KRj4DFBTBkA) |
+| Hangman Game | [Tutorial](https://youtu.be/ZFb_eaYtWwY) |
+| GitHub Repo Fetcher (Fetch API) | [Tutorial](https://youtu.be/uCKCSO8vkiU) |
+| Quiz Application | [Tutorial](https://youtu.be/T5QyLcmcMJ4) |
+
+### **Unique Coderz Academy** (Arabic)
+| Project | Link |
+|:---|:---|
+| JS Projects Playlist | [Playlist](https://youtube.com/playlist?list=PLtFbQRDJ11kGlRWp8MFhqlbO3ZmxIa3RE) |
+| Recipe App | [Playlist](https://youtube.com/playlist?list=PLtFbQRDJ11kEMjSzhHKMdcIuLiIywYWjH) |
+| Product Management System (CRUD) | [Tutorial](https://youtu.be/nJZAvdUhUMs) |
+| E-Commerce Shopping Cart | [Playlist](https://youtube.com/playlist?list=PLtFbQRDJ11kHCgyFid3khHdOk0VEHiJ3e) |
+
+### **Traversy Media & Lama Dev** (English)
+| Project | Link |
+|:---|:---|
+| Build 5 Projects (HTML/CSS/JS) | [Tutorial](https://youtu.be/JkeyKeK3V24) |
+| Netflix Landing Page Clone | [Tutorial](https://youtu.be/P7t13SGytRk) |
+| Movie Website (90 min) | [Tutorial](https://youtu.be/AOlkcLtyXkw) |
+| E-Commerce Website | [Tutorial](https://youtu.be/b3Gqq_k-g24) |
+
+---
+
+##  Problem-Solving
+
+> Sharpen your algorithmic thinking alongside JavaScript mastery.
+
+| Platform | Focus |
+|:---|:---|
+| [JSchallenger](https://www.jschallenger.com/) | JavaScript-specific challenges |
+| [FreeCodeCamp — JS Algorithms](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/) | Structured JS problems |
+| [NeetCode Roadmap](https://neetcode.io/roadmap) | Problem-solving roadmap |
+| [LeetCode](https://leetcode.com/) | Start Easy → Medium → Hard |
+
+---
+
+##  Extra JavaScript Resources
+
+### **Interactive & Reading**
+| Resource | Type |
+|:---|:---:|
+| [Learn JavaScript (Interactive)](https://learnjavascript.online/) |  Interactive |
+| [The Modern JS Tutorial](https://javascript.info/) |  Reference |
+
+### **YouTube Channels**
+| Channel | Focus |
+|:---|:---|
+| [Traversy Media](https://www.youtube.com/@TraversyMedia) | Crash courses & projects |
+| [Elzero Web School](https://www.youtube.com/@ElzeroWebSchool) | Arabic full courses |
+| [FreeCodeCamp](https://www.youtube.com/@freecodecamp) | Long-form deep dives |
+| [Unique Coderz Academy](https://www.youtube.com/@UniqueCoderzAcademy) | Arabic JS projects |
+
+### **Paid Courses (Optional)**
+| Course | Platform |
+|:---|:---|
+| [The Complete JavaScript Course 2023 — Jonas Schmedtmann](https://www.udemy.com/course/the-complete-javascript-course/) | Udemy (Recommended) |
+
+---
+
+##  Interview Prep
+
+| Resource | Type |
+|:---|:---:|
+| [JavaScript Interview Questions (GitHub)](https://github.com/FADL285/javascript-interview-questions) |  |

--- a/Front End/roadmap-03-angular.md
+++ b/Front End/roadmap-03-angular.md
@@ -1,0 +1,41 @@
+# 🅰️ Phase 3: Angular Ecosystem
+*Enterprise Scale & Structure*
+
+> **"One framework. Mobile & Desktop."**
+
+---
+
+## 🗺️ The Learning Path
+
+### **1. Prerequisites**
+*   **TypeScript:** Interfaces, Types, Classes, Generics.
+*   **RxJS:** Observables, Subjects, Operators (Basic understanding).
+
+### **2. Core Angular**
+*   **Concepts:** Modules, Components, Directives, Services, Dependency Injection.
+*   **Official Docs:** [Angular.io](https://angular.io/docs)
+*   **Tutorials:**
+    *   [Angular for Beginners (FreeCodeCamp)](https://youtu.be/3qBXWUpoPHo)
+    *   [Coding from A to Z (Arabic Playlist)](https://youtube.com/playlist?list=PLgU7izgeR2lwwNRNY4fYQf3GZawV-EGnW)
+    *   [Monsterlessons Academy](https://youtube.com/playlist?list=PLEjh-YiSBCDLC_zhXQ2J5SkHrLHdmV8qc)
+
+### **3. Reactive Programming (RxJS)**
+*   **Resources:**
+    *   [Learn RxJS](https://www.learnrxjs.io/)
+    *   [RxJS in Angular (Arabic)](https://youtube.com/playlist?list=PLgU7izgeR2lxCLqerQWZYBvv_0UTtPnWb)
+
+---
+
+## 🛠️ Recommended Projects
+
+### **Beginner**
+*   **Admin Dashboard:** [Tutorial](https://youtu.be/s7bKr_-GLtM)
+*   **Realtime Chat:** [Tutorial](https://youtu.be/Dg7bZUFopUo)
+*   **Weather App:** [Tutorial](https://youtu.be/fk0WoYnMbRo)
+
+### **Intermediate**
+*   **Movie App:** [Tutorial](https://youtu.be/rmPj2Qlbz3g)
+*   **Angular 17 Projects:** [Playlist](https://youtube.com/playlist?list=PL7JmcZV0UQtU5ds45KRtSXA19sOntKTnI)
+
+### **Advanced**
+*   **Spotify Web App Clone:** [Tutorial](https://youtu.be/FzlwWh5lLVU)

--- a/Front End/roadmap-03-react.md
+++ b/Front End/roadmap-03-react.md
@@ -1,0 +1,237 @@
+# ⚛️ Phase 3: React & Next.js Ecosystem
+*Industry Leader & Flexibility*
+
+> **"Learn once, write anywhere."**
+
+---
+
+## ✅ Prerequisites Checklist
+
+Before starting React, make sure you're comfortable with:
+
+| Concept | Details |
+|:---|:---|
+| **JavaScript Fundamentals** | Syntax, Variables, Arrays, Objects, Events, Functions, Loops, Conditions |
+| **Higher Order Methods** | `forEach`, `map`, `filter`, `reduce`, `sort` |
+| **Arrow Functions** | Lexical `this` keyword |
+| **ES6 Modules** | `import` / `export` |
+| **Promises** | `async` / `await`, Fetch API |
+| **Destructuring** | Arrays & Objects |
+| **Classes** | Constructors, Methods, Inheritance |
+| **Spread Operator** | `...` syntax |
+| **NPM** | Package management |
+| **Webpack & Babel** | Basic understanding of how they work |
+
+---
+
+##  The Learning Path
+
+### **1. Core React**
+*   **Official Docs:** [React.dev](https://react.dev/)
+*   **Tutorials (Arabic):**
+    *   [Kimz Codes — Part 1: React Hooks](https://www.youtube.com/watch?v=RgtTrM_sflo&list=PLejc1JbD4ZFSaQIFNstRIrbm_fqb12Q59)
+    *   [Kimz Codes — Part 2: LifeCycle](https://www.youtube.com/playlist?list=PLejc1JbD4ZFQa9YDF5pzB4JFbJovh3TN9)
+    *   [Kimz Codes — Part 3: Performance Optimization](https://www.youtube.com/watch?v=AZ41NpgebPA&list=PLejc1JbD4ZFTYdkjzqYBujf7UCVQyn_aq)
+    *   [Kimz Codes — Part 4: Advanced React](https://www.youtube.com/watch?v=aC9vgsUorPE&list=PLejc1JbD4ZFTiDCCVu_uCW0GXqyvhtbf8)
+    *   [Code Zone (Arabic Course)](https://youtube.com/playlist?list=PLQtNtS-WfRa9LbmD8ON7rWhn-AtKTGdkn)
+*   **Tutorials (English):**
+    *   [FreeCodeCamp React Course (2022)](https://www.youtube.com/watch?v=bMknfKXIFA8)
+
+*   **Paid Courses (Optional):**
+    *   [The Ultimate React Course — Jonas Schmedtmann](https://www.udemy.com/course/the-ultimate-react-course/) (Recommended)
+    *   [React — The Complete Guide — Maximilian Schwarzmuller](https://www.udemy.com/course/react-the-complete-guide-incl-redux/)
+
+---
+
+### **2. State Management (Redux Toolkit)**
+*   **Why?** Managing global state in complex apps.
+*   **Docs:** [Redux Official Docs](https://redux.js.org/)
+*   **Tutorials (Arabic):**
+    *   [Kimz Codes — Redux Toolkit](https://youtube.com/playlist?list=PLejc1JbD4ZFREfrBoSl8tjAPZOY6HNqZv)
+    *   [Kimz Codes — Redux Toolkit Build Book Store](https://youtube.com/playlist?list=PLejc1JbD4ZFQFvS469VXyCPO_py_kvVD5)
+    *   [Index Academy — Redux With React](https://youtube.com/playlist?list=PLDQ11FgmbqQObr_XGBVQiRr89YitNq-zc)
+*   **Tutorials (English):**
+    *   [Redux Tutorial — FreeCodeCamp](https://youtu.be/zrs7u6bdbUw)
+*   **Paid (Optional):**
+    *   Included in Jonas & Maximilian courses above.
+
+---
+
+### **3. Modern Styling (Tailwind CSS)**
+*   **Tutorials:**
+    *   [Tailwind CSS Crash Course — Ag Coding](https://youtube.com/playlist?list=PLnD96kXp-_pMR9cBUmvsz_kIIt9bv2UIP)
+    *   [Learn Tailwind in One Video — Termez Academy](https://youtu.be/Pk3hhCJG2Dk) (Arabic)
+*   **Practice:**
+    *   ��� [Build a Responsive Plant Website](https://youtu.be/zKguO4oaAGs)
+    *   ��� [Full Website Using Tailwind](https://youtu.be/9Px2cwdQ8PM)
+
+---
+
+### **4. TypeScript**
+
+> TypeScript is a syntactic superset of JavaScript that adds **static typing**. It helps catch errors early, makes code self-documenting, and is essential for professional React/Angular development.
+
+#### Why TypeScript?
+- JavaScript is loosely typed — hard to trace data types across a codebase.
+- TypeScript catches type mismatches at **compile time**, not runtime.
+- Industry standard for any serious React or Angular project.
+
+#### Resources
+| Resource | Type |
+|:---|:---:|
+| [Elzero — TypeScript in Arabic](https://www.youtube.com/watch?v=yUndnE-2osg&list=PLDoPjvoNmBAy532K9M_fjiAmrJ0gkCyLJ) | ��� Arabic |
+| [Net Ninja — TypeScript](https://www.youtube.com/watch?v=2pZmKW9-I_k&list=PL4cUxeGkcC9gUgr39Q_yD6v-bSyMwKPUI) | ��� English |
+| [TypeScript Crash Course for React/Next — Lama Dev](https://www.youtube.com/watch?v=WlxcujsvcIY) | ��� English |
+
+#### React + TypeScript Project
+*   ��� [Build eCommerce App — React, TypeScript, Redux Toolkit](https://youtube.com/playlist?list=PLejc1JbD4ZFS4sEpIpLfD18FEnEpafVbz)
+
+---
+
+### **5. Meta-Framework (Next.js)**
+*   **Why?** SSR, SEO, and Fullstack capabilities.
+*   **Docs:** [Next.js Official Docs](https://nextjs.org/)
+*   **Tutorials (Arabic):**
+    *   [Next.js Full Course — Termez Academy](https://youtu.be/_t4c-vxalp4)
+    *   [Next.js 13 Course — Index Academy](https://youtu.be/KN66vLV0QZk)
+*   **Tutorials (English):**
+    *   [Next.js 14 Full Course — JS Mastery](https://youtu.be/wm5gMKuwSYk)
+*   **Paid (Optional):**
+    *   [Next.js — Stephen Grider](https://www.udemy.com/course/next-js-the-complete-developers-guide/) (Recommended)
+    *   [Next.js 14 & React — Maximilian Schwarzmuller](https://www.udemy.com/course/nextjs-react-the-complete-guide/)
+
+---
+
+## ��� React Ecosystem Libraries
+
+> Essential libraries every React developer should know.
+
+### **Navigation**
+| Resource | Type |
+|:---|:---:|
+| [React Router Tutorial — Codevolution](https://youtube.com/playlist?list=PLC3y8-rFHvwjkxt8TOteFdT_YmzwpBlrG) | ��� Playlist |
+| [React Router — Complete Tutorial](https://youtu.be/oTIJunBa6MA) | ��� Video |
+
+### **UI Libraries**
+| Resource | Type |
+|:---|:---:|
+| [Material UI Tutorial — Net Ninja](https://youtube.com/playlist?list=PL4cUxeGkcC9gjxLvV4VEkZ6H6H4yWuS58) | ��� Playlist |
+| [Shadcn UI Tutorial — Net Ninja](https://youtube.com/playlist?list=PL4cUxeGkcC9h1NXLUuiAQ7c4UtdEInqma) | ��� Playlist |
+
+### **Data Fetching**
+| Resource | Type |
+|:---|:---:|
+| [Learn React Query in 50 Minutes](https://youtu.be/r8Dg0KVnfMA) | ��� Video |
+| [React Query — Complete Tutorial](https://youtu.be/8K1N3fE-cDs) | ��� Video |
+
+### **Form Validation**
+| Resource | Type |
+|:---|:---:|
+| [React Hook Form Crash Course (Arabic)](https://youtu.be/8OO4xhJnniU) | ��� Arabic |
+| [Learn Zod in 30 Minutes](https://youtu.be/L6BE-U3oy80) | ��� English |
+| [React Hook Form + Zod — Complete](https://youtu.be/cc_xmawJ8Kg) | ��� English |
+| [React Hook Form Tutorials — Playlist](https://youtube.com/playlist?list=PLC3y8-rFHvwjmgBr1327BA5bVXoQH-w5s) | ��� Playlist |
+
+---
+
+## ��� The 8-Week Specialist Schedule
+
+> **"This is where you become an Engineer."**
+
+### ��� Module A: The React Standard (Weeks 1-4)
+
+#### **Week 1: Thinking in React**
+*   **Concepts:** Components, JSX, Props, State (useState), Effects (useEffect).
+*   **Study:** [React.dev: Describing the UI](https://react.dev/learn/describing-the-ui).
+*   **Task 1:** **[The Static Tweet]**
+    *   Build a Twitter Card component. Passing data via props.
+*   **Task 2:** **[Interactive Accordion]**
+    *   Show/Hide content using `useState`.
+
+#### **Week 2: Forms & Side Effects**
+*   **Concepts:** Controlled Components, useRef, useEffect Cleanup, Custom Hooks.
+*   **Study:** [React.dev: Managing State](https://react.dev/learn/managing-state).
+*   **Task 1:** **[Registration Form]**
+    *   Validate input in real-time. Disable submit button if invalid.
+*   **Task 2:** **[Window Resizer Hook]**
+    *   Create a custom hook `useWindowSize()` that returns width/height.
+
+#### **Week 3: Data-Driven React (API & Routing)**
+*   **Concepts:** React Router v6, Fetching Data (useEffect vs Query), Handling Loading/Error states.
+*   **Study:** [React Router Tutorial](https://reactrouter.com/en/main/start/tutorial).
+*   **Task:** **[Movie Search App]**
+    *   Fetch from TMDB API.
+    *   Pages: Home (Search), MovieDetail (Dynamic Route `/:id`).
+
+#### **Week 4: Global State (Redux Toolkit)**
+*   **Concepts:** Store, Slices, Dispatch, Selectors.
+*   **Task:** **[E-Commerce Cart System]**
+    *   Add items to cart from any page.
+    *   Cart persists in LocalStorage (use Middleware/Subscription).
+    *   **Challenge:** Implement "Undo" action (remove last item).
+
+---
+
+### ��� Module B: The Next.js Framework (Weeks 5-8)
+
+#### **Week 5: Next.js Fundamentals (App Router)**
+*   **Concepts:** Server vs Client Components, File-based Routing, Layouts.
+*   **Study:** [Next.js Dashboard Tutorial](https://nextjs.org/learn).
+*   **Task:** **[Simple Blog]**
+    *   Use Markdown files as a database.
+    *   Render Static Pages (SSG).
+
+#### **Week 6: Server Actions & Databases**
+*   **Concepts:** Server Actions (No API routes), Prisma (ORM), Supabase/PostgreSQL.
+*   **Task:** **[Guestbook App]**
+    *   User can sign the guestbook (Form submission without `useState`).
+    *   Save to Database.
+    *   Revalidate Path to show new entry immediately.
+
+#### **Week 7: Authentication & Optimization**
+*   **Concepts:** NextAuth (Auth.js), Middleware, Image Optimization, Fonts.
+*   **Task:** **[Protected Dashboard]**
+    *   Login with GitHub.
+    *   Protect `/dashboard` route using Middleware.
+
+#### **Week 8: The Final Capstone**
+*   **Project:** **[Fullstack LMS (Learning Management System)]**
+*   **Tech Stack:** Next.js, Tailwind, Prisma, Stripe (Mock), Mux (Video).
+*   **Requirements:**
+    *   **Teacher Mode:** Create courses, upload chapters.
+    *   **Student Mode:** Watch videos, mark complete.
+    *   **Progress Tracking:** Calculate % completion.
+
+---
+
+##  Recommended Projects
+
+### **Beginner**
+| Project | Link |
+|:---|:---|
+| Brand Page | [Tutorial](https://youtu.be/W7up-w1QYpw) |
+| Contact Us Page | [Tutorial](https://www.youtube.com/watch?v=hrHIzqyq06U) |
+| Foody Zone | [Tutorial](https://youtu.be/i__4ul5yXFc) |
+| Todo App | [Tutorial](https://www.youtube.com/watch?v=LoYbN6qoQHA) |
+
+### **Intermediate**
+| Project | Link |
+|:---|:---|
+| Invoice App (React) | [Playlist](https://youtube.com/playlist?list=PLakmP0ibjfQcNNh7PnmIQ9zTm2bLM_wCC) |
+| 25 React Projects | [Playlist](https://youtube.com/playlist?list=PLJT9n0q3md18xl4PWqzqNFUEp9DbBmogZ) |
+
+### **Advanced**
+| Project | Link |
+|:---|:---|
+| App Clones (Netflix, Spotify, etc.) | [Playlist](https://youtube.com/playlist?list=PL-J2q3Ga50oMQa1JdSJxYoZELwOJAXExP) |
+
+---
+
+## ��� YouTube Channels
+
+| Channel | Focus |
+|:---|:---|
+| [JavaScript Mastery](https://www.youtube.com/@javascriptmastery) | React & Next.js projects |
+| [Traversy Media](https://www.youtube.com/@TraversyMedia) | Crash courses |
+| [Lama Dev](https://www.youtube.com/@LamaDev) | Fullstack clones |
+| [FreeCodeCamp](https://www.youtube.com/@freecodecamp) | Long-form courses |

--- a/Front End/roadmap-03-vue.md
+++ b/Front End/roadmap-03-vue.md
@@ -1,0 +1,60 @@
+# 💚 Phase 3: Vue.js Ecosystem
+*Simplicity & Performance*
+
+> **"The Progressive JavaScript Framework."**
+
+---
+
+## 🗺️ The Learning Path
+
+### **1. Vue Fundamentals**
+*   **Core Concepts:** Directives, Reactivity, Components.
+*   **Official Docs:** [Vue.js Guide](https://vuejs.org/guide/introduction.html)
+*   **Tutorials:**
+    *   [Vue.js Crash Course (English)](https://www.youtube.com/watch?v=YrxBCBibVo0)
+    *   [Vue for Beginners (Arabic)](https://www.youtube.com/playlist?list=PLDoPjvoNmBAxr5AqK3Yz4DWYKVSmIFziw) (Elzero)
+
+### **2. Vue 3 Features**
+*   **Focus:** Composition API, Teleport, Fragments.
+*   **Resources:**
+    *   [What's New in Vue 3?](https://www.youtube.com/watch?v=bwItFdPt-6M)
+    *   [Vue 3 New Features (Arabic)](https://www.youtube.com/playlist?list=PLLXntwspGdhCrdh_7xqzz0s3sH4sWlEiQ)
+
+### **3. State Management (Pinia)**
+*   **Why?** The modern successor to Vuex. Simple & Type-safe.
+*   **Resources:**
+    *   [Pinia Official Docs](https://pinia.vuejs.org/)
+    *   [Pinia Tutorial (Net Ninja)](https://www.youtube.com/playlist?list=PL4cUxeGkcC9hp28dYyYBy3xoOdoeNw-hD)
+    *   [Pinia Explanation (Arabic)](https://www.youtube.com/watch?v=IwNyiqUQa-8)
+
+### **4. Meta-Framework (Nuxt.js)**
+*   **Why?** Server-side Rendering (SSR) & Static Site Generation (SSG).
+*   **Resources:**
+    *   [Nuxt.js Docs](https://nuxt.com/)
+
+---
+
+## 🛠️ Ecosystem & Tools
+
+### **Styling**
+*   **Tailwind CSS:** Utility-first framework.
+*   **DaisyUI:** Component library for Tailwind.
+
+### **Data Fetching**
+*   **Axios:** Standard HTTP client.
+*   **TanStack Query:** For caching and syncing server state.
+
+### **Testing**
+*   **Vitest:** Blazing fast unit testing (Vite-native).
+
+---
+
+## 🚀 Projects to Build
+1.  **Todo App** (with Pinia)
+2.  **Weather Dashboard** (API Integration)
+3.  **E-Commerce Catalog**
+4.  **Real-time Chat App**
+
+## ✍️ Credits
+
+- **Ameen Mohamed** - *Vue.js Roadmap Contributor*


### PR DESCRIPTION
- Replace single-file roadmap with structured multi-file curriculum
- Add Phase 1 (Foundation): full HTML/CSS assignment tables, Git resources, challenge platforms, interview prep
- Add Phase 2 (Core Engineering): full JS assignment tables, Bootstrap, SASS, NPM/Webpack, practice projects, problem-solving
- Add Phase 3 (Specialization): React/Next.js path with TypeScript, Redux, ecosystem libraries; Vue path with Pinia/Nuxt; Angular path with RxJS
- Update Readme.md as a 2026 hub linking to all phase files
- Add tech badges, curriculum table, learning objectives, and setup guide

Credits: Abdelrahman Ataa (Frontend Head 2025-2026), Ameen Mohamed (Vue)